### PR TITLE
[DO NOT MERGE] Quartic constraint fails

### DIFF
--- a/src/starks/example/mod.rs
+++ b/src/starks/example/mod.rs
@@ -2,4 +2,5 @@ pub mod dummy_air;
 pub mod fibonacci_2_columns;
 pub mod fibonacci_rap;
 pub mod quadratic_air;
+pub mod quartic_air;
 pub mod simple_fibonacci;

--- a/src/starks/example/quartic_air.rs
+++ b/src/starks/example/quartic_air.rs
@@ -1,0 +1,125 @@
+use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
+use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
+
+use crate::starks::{
+    constraints::boundary::{BoundaryConstraint, BoundaryConstraints},
+    context::AirContext,
+    frame::Frame,
+    proof::options::ProofOptions,
+    trace::TraceTable,
+    traits::AIR,
+};
+
+#[derive(Clone)]
+pub struct QuarticAIR<F>
+where
+    F: IsFFTField,
+{
+    context: AirContext,
+    trace_length: usize,
+    pub_inputs: QuarticPublicInputs<F>,
+}
+
+#[derive(Clone, Debug)]
+pub struct QuarticPublicInputs<F>
+where
+    F: IsFFTField,
+{
+    pub a0: FieldElement<F>,
+}
+
+impl<F> AIR for QuarticAIR<F>
+where
+    F: IsFFTField,
+{
+    type Field = F;
+    type RAPChallenges = ();
+    type PublicInputs = QuarticPublicInputs<Self::Field>;
+
+    fn new(
+        trace_length: usize,
+        pub_inputs: &Self::PublicInputs,
+        proof_options: &ProofOptions,
+    ) -> Self {
+        let context = AirContext {
+            proof_options: proof_options.clone(),
+            trace_columns: 1,
+            transition_degrees: vec![4],
+            transition_exemptions: vec![1],
+            transition_offsets: vec![0, 1],
+            num_transition_constraints: 1,
+            num_transition_exemptions: 1,
+        };
+
+        Self {
+            trace_length,
+            context,
+            pub_inputs: pub_inputs.clone(),
+        }
+    }
+
+    fn build_auxiliary_trace(
+        &self,
+        _main_trace: &TraceTable<Self::Field>,
+        _rap_challenges: &Self::RAPChallenges,
+    ) -> TraceTable<Self::Field> {
+        TraceTable::empty()
+    }
+
+    fn build_rap_challenges<T: Transcript>(&self, _transcript: &mut T) -> Self::RAPChallenges {}
+
+    fn compute_transition(
+        &self,
+        frame: &Frame<Self::Field>,
+        _rap_challenges: &Self::RAPChallenges,
+    ) -> Vec<FieldElement<Self::Field>> {
+        let first_row = frame.get_row(0);
+        let second_row = frame.get_row(1);
+
+        vec![&second_row[0] - &first_row[0] * &first_row[0] * &first_row[0] * &first_row[0]]
+    }
+
+    fn number_auxiliary_rap_columns(&self) -> usize {
+        0
+    }
+
+    fn boundary_constraints(
+        &self,
+        _rap_challenges: &Self::RAPChallenges,
+    ) -> BoundaryConstraints<Self::Field> {
+        let a0 = BoundaryConstraint::new_simple(0, self.pub_inputs.a0.clone());
+
+        BoundaryConstraints::from_constraints(vec![a0])
+    }
+
+    fn context(&self) -> &AirContext {
+        &self.context
+    }
+
+    fn composition_poly_degree_bound(&self) -> usize {
+        4 * self.trace_length()
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
+    }
+
+    fn pub_inputs(&self) -> &Self::PublicInputs {
+        &self.pub_inputs
+    }
+}
+
+pub fn quartic_trace<F: IsFFTField>(
+    initial_value: FieldElement<F>,
+    trace_length: usize,
+) -> TraceTable<F> {
+    let mut ret: Vec<FieldElement<F>> = vec![];
+
+    ret.push(initial_value);
+
+    for i in 1..(trace_length) {
+        ret.push(ret[i - 1].clone() * ret[i - 1].clone() * ret[i - 1].clone() * ret[i - 1].clone());
+    }
+
+    TraceTable::new_from_cols(&[ret])
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -23,6 +23,7 @@ use lambdaworks_stark::{
             fibonacci_2_columns::{self, Fibonacci2ColsAIR},
             fibonacci_rap::{fibonacci_rap_trace, FibonacciRAP, FibonacciRAPPublicInputs},
             quadratic_air::{self, QuadraticAIR, QuadraticPublicInputs},
+            quartic_air::{self, QuarticAIR, QuarticPublicInputs},
             simple_fibonacci::{self, FibonacciAIR, FibonacciPublicInputs},
         },
         proof::options::{ProofOptions, SecurityLevel},
@@ -105,6 +106,28 @@ fn test_prove_quadratic() {
 
     let proof = prove::<F, QuadraticAIR<F>>(&trace, &pub_inputs, &proof_options).unwrap();
     assert!(verify::<F, QuadraticAIR<F>>(
+        &proof,
+        &pub_inputs,
+        &proof_options
+    ));
+}
+
+#[test_log::test]
+fn test_prove_quartic() {
+    let trace = quartic_air::quartic_trace(FE::from(3), 8);
+
+    // let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions {
+        blowup_factor: 4,
+        fri_number_of_queries: 3,
+        coset_offset: 3,
+        grinding_factor: 1,
+    };
+
+    let pub_inputs = QuarticPublicInputs { a0: FE::from(3) };
+
+    let proof = prove::<F, QuarticAIR<F>>(&trace, &pub_inputs, &proof_options).unwrap();
+    assert!(verify::<F, QuarticAIR<F>>(
         &proof,
         &pub_inputs,
         &proof_options


### PR DESCRIPTION
Proof of concept for issue
`quartic_constraint.rs` is just a copy of `quadratic_constraint.rs` modified to make the constraint quartic instead of quadratic.
```
mcarilli:src$ cargo test --release quartic
...
---- test_prove_quartic stdout ----
[2023-07-21T01:49:13Z ERROR lambdaworks_stark::starks::verifier] FRI verification failed
thread 'test_prove_quartic' panicked at 'assertion failed: verify::<F, QuarticAIR<F>>(&proof, &pub_inputs, &proof_options)', tests/integration_tests.rs:130:5
```